### PR TITLE
fix: replace __dirname with ESM-compatible equivalent in infra/app.ts

### DIFF
--- a/infra/app.ts
+++ b/infra/app.ts
@@ -4,9 +4,12 @@ import * as events from "aws-cdk-lib/aws-events";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as path from "path";
+import { fileURLToPath } from "url";
 import {
   ConversationPipelineConstruct,
 } from "../packages/pipeline-cdk/src/conversationPipeline";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const app = new cdk.App();
 


### PR DESCRIPTION
__dirname is not available in ES module scope (package.json has "type": "module").
Derive it from import.meta.url using fileURLToPath and path.dirname.

https://claude.ai/code/session_01G3JdcJjDir1HhLXjDPVw9T