### PR TITLE
fix: correct Lambda asset path and add handlers build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Generate code from contracts
         run: npm run generate
 
+      - name: Build Lambda handlers
+        run: npm run build --workspaces --if-present
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/infra/app.ts
+++ b/infra/app.ts
@@ -37,5 +37,5 @@ const bus = events.EventBus.fromEventBusName(stack, "SharedBus", busName);
 new ConversationPipelineConstruct(stack, "ConversationPipeline", {
   dynamoTable: table,
   eventBus: bus,
-  lambdaCode: lambda.Code.fromAsset(path.join(__dirname, "handlers")),
+  lambdaCode: lambda.Code.fromAsset(__dirname),
 });


### PR DESCRIPTION
Two issues causing CDK synthesis to fail:

1. Asset path mismatch: `lambda.Code.fromAsset(path.join(__dirname, "handlers"))` zips infra/handlers/ as the zip root, but the construct uses handler strings like `handlers/assembleContext.handler` which require a handlers/ *subdirectory* inside the zip. Fixed by passing `__dirname` (the infra/ dir itself) so the zip contains handlers/ as a subdirectory at the expected path.

2. Missing build step: deploy.yml ran CDK before compiling the handler TypeScript. Added `npm run build --workspaces --if-present` to compile all workspace packages (including Lambda handlers) before CDK synthesises the asset.

https://claude.ai/code/session_01G3JdcJjDir1HhLXjDPVw9T