### PR TITLE
fix: remove registry-url from setup-node to prevent GitHub token leak…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          registry-url: "https://npm.pkg.github.com"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://npm.pkg.github.com'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
…ing to npmjs.org

When setup-node is configured with registry-url: 'https://npm.pkg.github.com', it creates a user-level .npmrc that causes NODE_AUTH_TOKEN (a GitHub token) to be sent to registry.npmjs.org when downloading public packages like aws-cdk-lib, resulting in a 403 error.

Removing registry-url from both workflows fixes this. The workspace .npmrc files already handle @melodysdad scoped package auth via ${NPM_TOKEN}, and each package's publishConfig.registry handles publishing to GitHub Packages.

https://claude.ai/code/session_012ZFqXuRjFZWuVHyJ1gDmXW